### PR TITLE
Optimise compatibility with SE

### DIFF
--- a/True-Nukes_0.3.4/control.lua
+++ b/True-Nukes_0.3.4/control.lua
@@ -172,7 +172,7 @@ local function optimisedChunkLoadHandler(chunkPosAndArea, chunkLoaderStruct, kil
       end
     end
     local crater_system_to_use = crater_system
-    if(game.surfaces[surface_index].count_tiles_filtered{position = originPos, name = crater_system_se.interesting_tiles, limit=1} ~= 0) then
+    if((game.active_mods["space-exploration"]) and (game.surfaces[surface_index].count_tiles_filtered{position = originPos, name = crater_system_se.interesting_tiles, limit=1} ~= 0)) then
       crater_system_to_use = crater_system_se
     end
     -- crater


### PR DESCRIPTION
When using a lot of modded tiles the compatibility check would cause enormous freezes and make nukes unusable.

I haven't checked if this breaks compatibility, so I haven't tested this with space-exploration enabled only without the plugin, but this does increase performance by a lot when using a lot of modded tiles.

count_tiles_filtered is slower the more modded tiles you have, so when using bob's mod, which adds a lot of tiles, it makes the mod completely unusable since every chunk generation takes about 1 second to finish, so nukes take around 2 hours to finish and after a nuke there are enourmous lag spikes, and after I while I figured out that this small piece of code was the culprit.