### PR TITLE
Fix for Plutonium Energy 1.5.0 compatibility

### DIFF
--- a/True-Nukes_0.3.21/prototypes/nukes/compatibility/plutonium-energy.lua
+++ b/True-Nukes_0.3.21/prototypes/nukes/compatibility/plutonium-energy.lua
@@ -6,10 +6,10 @@ end
 data.raw.technology["plutonium-atomic-bomb"] = nil
 
 if (data.raw.technology["expanded-atomics"]) then
-  table.insert(data.raw.technology["expanded-atomics"].prerequisites, "plutonium-enrichment-process")
+  table.insert(data.raw.technology["expanded-atomics"].prerequisites, "nuclear-breeding")
 end
 if (data.raw.technology["californium-processing"]) then
-  table.insert(data.raw.technology["californium-processing"].prerequisites, "plutonium-enrichment-process")
+  table.insert(data.raw.technology["californium-processing"].prerequisites, "nuclear-breeding")
 end
 
 if (data.raw.technology["tritium-breeder-fuel-cell"]) then


### PR DESCRIPTION
Plutonium enrichment process was removed, replaced by nuclear breeding.

Fixes #19